### PR TITLE
Only use user agent in node env

### DIFF
--- a/src/linkup-client.ts
+++ b/src/linkup-client.ts
@@ -41,13 +41,18 @@ export class LinkupClient {
           ? StructuredOutputSchema
           : never
   > {
+    let headers: Record<string, string> = {
+      Authorization: `Bearer ${this.apiKey}`,
+    };
+
+    if (typeof window === 'undefined') {
+      headers['User-Agent'] = this.USER_AGENT;
+    }
+
     return axios
       .post('/search', this.sanitizeParams(params), {
         baseURL: this.baseUrl,
-        headers: {
-          'User-Agent': this.USER_AGENT,
-          Authorization: `Bearer ${this.apiKey}`,
-        },
+        headers,
       })
       .then((response) =>
         this.formatResponse<T>(response.data, params.outputType),


### PR DESCRIPTION
In web browsers, modifying the User-Agent header for HTTP requests via JavaScript is generally impossible due to security and standardization reasons. Modern browsers restrict access to the User-Agent header to prevent spoofing and ensure consistency in identifying the client (browser, version, OS).

Instead, we can use alternative methods to send custom information in HTTP requests such as Custom Headers like X-Custom-User-Agent to include SDK-specific details.