### PR TITLE
feat(search): add support for favicon

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linkup-sdk",
-  "version": "1.0.9",
+  "version": "0.0.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
@@ -75,6 +75,8 @@
     ]
   },
   "commitlint": {
-    "extends": ["@commitlint/config-conventional"]
+    "extends": [
+      "@commitlint/config-conventional"
+    ]
   }
 }

--- a/src/__tests__/linkup-client.test.ts
+++ b/src/__tests__/linkup-client.test.ts
@@ -127,7 +127,7 @@ describe('LinkupClient', () => {
       baseURL: 'http://foo.bar/baz',
       headers: {
         Authorization: 'Bearer 1234',
-        'User-Agent': 'Linkup-JS-SDK/2.5.1',
+        'User-Agent': 'Linkup-JS-SDK/0.0.0',
       },
     });
   });
@@ -138,12 +138,14 @@ describe('LinkupClient', () => {
         answer: 'foo',
         sources: [
           {
+            favicon: 'http://foo.bar/favicon.ico',
             name: 'foo',
             snippet: 'foo bar baz',
             url: 'http://foo.bar/baz',
           },
           {
             content: 'foo bar baz',
+            favicon: 'http://foo.bar/favicon.ico',
             name: 'bar',
             type: 'text',
             url: 'http://foo.bar/baz',
@@ -167,10 +169,14 @@ describe('LinkupClient', () => {
     expect((result.sources.at(0) as Source)?.name).toEqual('foo');
     expect((result.sources.at(0) as Source)?.url).toEqual('http://foo.bar/baz');
     expect((result.sources.at(0) as Source)?.snippet).toEqual('foo bar baz');
+    expect((result.sources.at(0) as Source)?.favicon).toEqual('http://foo.bar/favicon.ico');
     expect((result.sources.at(1) as TextSearchResult)?.type).toEqual('text');
     expect((result.sources.at(1) as TextSearchResult)?.name).toEqual('bar');
     expect((result.sources.at(1) as TextSearchResult)?.url).toEqual('http://foo.bar/baz');
     expect((result.sources.at(1) as TextSearchResult)?.content).toEqual('foo bar baz');
+    expect((result.sources.at(1) as TextSearchResult)?.favicon).toEqual(
+      'http://foo.bar/favicon.ico',
+    );
     expect((result.sources.at(2) as ImageSearchResult)?.type).toEqual('image');
     expect((result.sources.at(2) as ImageSearchResult)?.name).toEqual('baz');
     expect((result.sources.at(2) as ImageSearchResult)?.url).toEqual('http://foo.bar/baz');
@@ -216,6 +222,7 @@ describe('LinkupClient', () => {
         sources: [
           {
             content: 'Lorem ipsum dolor sit amet',
+            favicon: 'http://foo.bar/favicon.ico',
             name: 'foo',
             type: 'text',
             url: 'http://foo.bar/baz',
@@ -237,6 +244,7 @@ describe('LinkupClient', () => {
       sources: [
         {
           content: 'Lorem ipsum dolor sit amet',
+          favicon: 'http://foo.bar/favicon.ico',
           name: 'foo',
           type: 'text',
           url: 'http://foo.bar/baz',

--- a/src/linkup-client.ts
+++ b/src/linkup-client.ts
@@ -1,6 +1,7 @@
 import axios, { AxiosInstance } from 'axios';
 import { ZodObject, ZodRawShape } from 'zod';
 import zodToJsonSchema from 'zod-to-json-schema';
+import { version } from '../package.json';
 import {
   ApiConfig,
   FetchParams,
@@ -12,7 +13,7 @@ import { refineError } from './utils/refine-error.utils';
 import { isZodObject } from './utils/schema.utils';
 
 export class LinkupClient {
-  private readonly USER_AGENT = 'Linkup-JS-SDK/2.5.1';
+  private readonly USER_AGENT = `Linkup-JS-SDK/${version}`;
   private readonly client: AxiosInstance;
 
   constructor(config: ApiConfig) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,6 +22,7 @@ export type StructuredSource = {
   content: string;
   name: string;
   type: string;
+  favicon: string;
 };
 
 export type SearchParams = {
@@ -65,6 +66,7 @@ export type TextSearchResult = {
   name: string;
   url: string;
   content: string;
+  favicon: string;
 };
 
 export type ImageSearchResult = {
@@ -82,6 +84,7 @@ export type Source = {
   name: string;
   url: string;
   snippet: string;
+  favicon: string;
 };
 
 export type LinkupApiError = {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,8 @@
     "forceConsistentCasingInFileNames": true,
     "declaration": true,
     "declarationMap": true,
-    "sourceMap": true
+    "sourceMap": true,
+    "resolveJsonModule": true
   },
   "include": ["src"],
   "exclude": ["node_modules", "**/__tests__/*"]


### PR DESCRIPTION
This PR adds support for favicon.

It also dynamically get the package version value to be used in the user agent header instead of an hardcoded value. Semantic release changes this value at release time, meaning the version in the repository (0.0.0) isn't the version hosted on npm.

