### PR TITLE
Expand SearchDepth type to include 'fast'

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -2,7 +2,7 @@
 import { ZodObject, ZodRawShape } from 'zod';
 import type { X402Signer } from './x402/types';
 
-export type SearchDepth = 'standard' | 'deep';
+export type SearchDepth = 'fast' | 'standard' | 'deep';
 
 export type ApiKeyConfig = { apiKey: string; baseUrl?: string };
 


### PR DESCRIPTION
You api support the fast search depth, yet the types are not aligned.

This PR fix this