### PR TITLE
Sync budget limit error mapping with platform API

### DIFF
--- a/src/__tests__/linkup-client.test.ts
+++ b/src/__tests__/linkup-client.test.ts
@@ -746,6 +746,19 @@ describe('LinkupClient', () => {
         },
       },
       {
+        description: '429 EXCEED_BUDGET_LIMIT',
+        ErrorClass: LinkupInsufficientCreditError,
+        expectedMessage: 'The API key has reached its budget limit.',
+        input: {
+          error: {
+            code: 'EXCEED_BUDGET_LIMIT',
+            details: [],
+            message: 'The API key has reached its budget limit.',
+          },
+          statusCode: 429,
+        },
+      },
+      {
         description: '429 TOO_MANY_REQUESTS',
         ErrorClass: LinkupTooManyRequestsError,
         expectedMessage: 'Too many requests',

--- a/src/utils/refine-error.utils.ts
+++ b/src/utils/refine-error.utils.ts
@@ -57,6 +57,7 @@ export const refineError = (e: LinkupApiError): LinkupError => {
     case 429:
       switch (code) {
         case 'INSUFFICIENT_FUNDS_CREDITS':
+        case 'EXCEED_BUDGET_LIMIT':
           return new LinkupInsufficientCreditError(message);
         case 'TOO_MANY_REQUESTS':
           return new LinkupTooManyRequestsError(message);


### PR DESCRIPTION
## Summary
- sync the JS SDK error refinement with the current platform gateway behavior for `EXCEED_BUDGET_LIMIT`
- map the platform's 429 budget-limit error to `LinkupInsufficientCreditError`
- add a focused regression test covering the new error-code mapping

## Why
The public gateway API can now return `EXCEED_BUDGET_LIMIT` for budget-capped API keys. The JS SDK previously treated that response as an unknown error, so its typed error handling had drifted from platform behavior.

## Validation
- `npm run build`
- `npm run lint`
- `npm test`