### PR TITLE
fix: align js sdk request shaping with platform api

### DIFF
--- a/src/__tests__/linkup-client.test.ts
+++ b/src/__tests__/linkup-client.test.ts
@@ -93,14 +93,42 @@ describe('LinkupClient', () => {
       expect(mockAxiosInstance.post).toHaveBeenCalledWith('/search', {
         depth: 'deep',
         excludeDomains: ['baz.com', 'qux.com'],
-        fromDate: fromDate.toISOString(),
+        fromDate: '2025-01-01',
         includeDomains: ['foo.com', 'bar.com'],
         includeImages: true,
         includeInlineCitations: true,
         maxResults: 10,
         outputType: 'sourcedAnswer',
         q: 'foo',
-        toDate: toDate.toISOString(),
+        toDate: '2025-01-02',
+      });
+    });
+
+    it('should preserve explicit false flags and forward string dates as-is', async () => {
+      mockAxiosInstance.post.mockResolvedValueOnce({
+        data: { results: [] },
+      } as AxiosResponse);
+
+      await underTest.search({
+        depth: 'standard',
+        fromDate: '2026-05-01',
+        includeImages: false,
+        includeSources: false,
+        outputType: 'structured',
+        query: 'foo',
+        structuredOutputSchema: { type: 'string' },
+        toDate: '2026-05-31',
+      });
+
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith('/search', {
+        depth: 'standard',
+        fromDate: '2026-05-01',
+        includeImages: false,
+        includeSources: false,
+        outputType: 'structured',
+        q: 'foo',
+        structuredOutputSchema: JSON.stringify({ type: 'string' }),
+        toDate: '2026-05-31',
       });
     });
 
@@ -373,7 +401,7 @@ describe('LinkupClient', () => {
           error: null,
           id: '2dbcc4bb-2c0d-4bcb-aaf5-44f7cbcf4eee',
           input: {
-            mode: 'Auto',
+            mode: 'auto',
             outputType: 'sourcedAnswer',
             q: 'What changed?',
             reasoningDepth: 'L',
@@ -395,7 +423,7 @@ describe('LinkupClient', () => {
         q: 'What changed?',
       });
       expect(result.input).toEqual({
-        mode: 'Auto',
+        mode: 'auto',
         outputType: 'sourcedAnswer',
         query: 'What changed?',
         reasoningDepth: 'L',
@@ -409,7 +437,7 @@ describe('LinkupClient', () => {
           error: null,
           id: 'abc-123',
           input: {
-            mode: 'Auto',
+            mode: 'auto',
             outputType: 'sourcedAnswer',
             q: 'deep question',
             reasoningDepth: 'XL',
@@ -708,11 +736,11 @@ describe('LinkupClient', () => {
         },
       },
       {
-        description: '402 PAYMENT_REQUIRED',
+        description: '402 X402_PAYMENT_REQUIRED',
         ErrorClass: LinkupPaymentRequiredError,
         expectedMessage: 'Payment required',
         input: {
-          error: { code: 'PAYMENT_REQUIRED', details: [], message: 'Payment required' },
+          error: { code: 'X402_PAYMENT_REQUIRED', details: [], message: 'Payment required' },
           statusCode: 402,
         },
       },

--- a/src/linkup-client.ts
+++ b/src/linkup-client.ts
@@ -161,19 +161,19 @@ export class LinkupClient {
       depth,
       outputType,
       q: query,
-      ...(includeImages && { includeImages }),
+      ...(includeImages !== undefined && { includeImages }),
       ...(includeDomains && { includeDomains }),
       ...(excludeDomains && { excludeDomains }),
-      ...(fromDate && { fromDate: fromDate.toISOString() }),
-      ...(toDate && { toDate: toDate.toISOString() }),
-      ...(maxResults && { maxResults }),
+      ...(fromDate && { fromDate: this.serializeDate(fromDate) }),
+      ...(toDate && { toDate: this.serializeDate(toDate) }),
+      ...(maxResults !== undefined && { maxResults }),
     };
 
-    if ('includeInlineCitations' in params && params.includeInlineCitations) {
+    if ('includeInlineCitations' in params && params.includeInlineCitations !== undefined) {
       result.includeInlineCitations = params.includeInlineCitations;
     }
 
-    if ('includeSources' in params && params.includeSources) {
+    if ('includeSources' in params && params.includeSources !== undefined) {
       result.includeSources = params.includeSources;
     }
 
@@ -203,10 +203,10 @@ export class LinkupClient {
       q: query,
       ...(includeDomains && { includeDomains }),
       ...(excludeDomains && { excludeDomains }),
-      ...(fromDate && { fromDate: fromDate.toISOString() }),
-      ...(toDate && { toDate: toDate.toISOString() }),
-      ...(mode && { mode }),
-      ...(reasoningDepth && { reasoningDepth }),
+      ...(fromDate && { fromDate: this.serializeDate(fromDate) }),
+      ...(toDate && { toDate: this.serializeDate(toDate) }),
+      ...(mode !== undefined && { mode }),
+      ...(reasoningDepth !== undefined && { reasoningDepth }),
     };
 
     if ('structuredOutputSchema' in params) {
@@ -222,6 +222,10 @@ export class LinkupClient {
     return JSON.stringify(
       isZodObject(schema) ? zodToJsonSchema(schema as ZodObject<ZodRawShape>) : schema,
     );
+  }
+
+  private serializeDate(value: Date | string): string {
+    return value instanceof Date ? value.toISOString().slice(0, 10) : value;
   }
 
   private sanitizeTaskRequest(task: TaskRequest): {

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,8 +35,8 @@ type BaseSearchRequestParams = {
   query: string;
   includeDomains?: string[];
   excludeDomains?: string[];
-  fromDate?: Date;
-  toDate?: Date;
+  fromDate?: Date | string;
+  toDate?: Date | string;
 };
 
 export type SearchParams = BaseSearchRequestParams & {


### PR DESCRIPTION
## Summary
- align search and research request date serialization with the platform documented  contract
- accept  date inputs in the public JS types and preserve explicitly provided  flags when shaping requests
- update client tests to cover normalized date handling and current x402 error code naming

## Validation
- 
- 
- 