### PR TITLE
fix: split budget limit error from insufficient credit

### DIFF
--- a/src/__tests__/linkup-client.test.ts
+++ b/src/__tests__/linkup-client.test.ts
@@ -2,6 +2,7 @@ import axios, { type AxiosResponse } from 'axios';
 import { z } from 'zod';
 import {
   LinkupAuthenticationError,
+  LinkupBudgetLimitExceededError,
   LinkupFetchError,
   LinkupFetchResponseTooLargeError,
   LinkupFetchUnsupportedContentTypeError,
@@ -786,7 +787,7 @@ describe('LinkupClient', () => {
       },
       {
         description: '429 EXCEED_BUDGET_LIMIT',
-        ErrorClass: LinkupInsufficientCreditError,
+        ErrorClass: LinkupBudgetLimitExceededError,
         expectedMessage: 'The API key has reached its budget limit.',
         input: {
           error: {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -72,6 +72,19 @@ export class LinkupInsufficientCreditError extends LinkupError {
   }
 }
 
+// Budget limit exceeded error, raised when the Linkup API returns a 429 status code.
+// It is returned when the API key has reached its configured budget limit.
+export class LinkupBudgetLimitExceededError extends LinkupError {
+  constructor(message?: string) {
+    super(message);
+    this.name = LinkupBudgetLimitExceededError.name;
+
+    if ('captureStackTrace' in Error) {
+      Error.captureStackTrace(this, LinkupBudgetLimitExceededError);
+    }
+  }
+}
+
 // Tasks queue limit exceeded error, raised when the Linkup API returns a 429 status code.
 // It is returned when you submit more pending tasks than your organization queue allows.
 export class LinkupTasksQueueLimitExceededError extends LinkupError {

--- a/src/utils/refine-error.utils.ts
+++ b/src/utils/refine-error.utils.ts
@@ -1,6 +1,7 @@
 import {
   FetchUrlIsFileError,
   LinkupAuthenticationError,
+  LinkupBudgetLimitExceededError,
   LinkupError,
   LinkupFetchError,
   LinkupFetchResponseTooLargeError,
@@ -66,8 +67,9 @@ export const refineError = (e: LinkupApiError): LinkupError => {
     case 429:
       switch (code) {
         case 'INSUFFICIENT_FUNDS_CREDITS':
-        case 'EXCEED_BUDGET_LIMIT':
           return new LinkupInsufficientCreditError(message);
+        case 'EXCEED_BUDGET_LIMIT':
+          return new LinkupBudgetLimitExceededError(message);
         case 'TASKS_QUEUE_LIMIT_EXCEEDED':
           return new LinkupTasksQueueLimitExceededError(message);
         case 'TOO_MANY_REQUESTS':


### PR DESCRIPTION
## Summary
- the JS SDK treated the platform error code EXCEED_BUDGET_LIMIT the same as INSUFFICIENT_FUNDS_CREDITS, even though the public API exposes them as distinct 429 error conditions
- added LinkupBudgetLimitExceededError and mapped EXCEED_BUDGET_LIMIT to it while keeping the existing insufficient-credit behavior unchanged
- updated the error contract test to assert the new dedicated error class

## Validation
- npm run build
- npm run lint
- npm test