### PR TITLE
fix: accept JSON schema strings in structured search params

### DIFF
--- a/src/__tests__/linkup-client.test.ts
+++ b/src/__tests__/linkup-client.test.ts
@@ -133,6 +133,28 @@ describe('LinkupClient', () => {
       });
     });
 
+    it('should forward structured output schemas passed as JSON strings without double encoding', async () => {
+      mockAxiosInstance.post.mockResolvedValueOnce({
+        data: { results: [] },
+      } as AxiosResponse);
+
+      const schema = JSON.stringify({ properties: { foo: { type: 'string' } }, type: 'object' });
+
+      await underTest.search({
+        depth: 'standard',
+        outputType: 'structured',
+        query: 'foo',
+        structuredOutputSchema: schema,
+      });
+
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith('/search', {
+        depth: 'standard',
+        outputType: 'structured',
+        q: 'foo',
+        structuredOutputSchema: schema,
+      });
+    });
+
     it('should use custom base URL if provided', async () => {
       const customMockInstance = {
         interceptors: {

--- a/src/linkup-client.ts
+++ b/src/linkup-client.ts
@@ -15,6 +15,7 @@ import {
   ResearchParams,
   ResearchTask,
   SearchParams,
+  StructuredInputSchema,
   Task,
   TaskRequest,
 } from './types';
@@ -218,7 +219,11 @@ export class LinkupClient {
     return result;
   }
 
-  private serializeStructuredOutputSchema(schema: unknown): string {
+  private serializeStructuredOutputSchema(schema: StructuredInputSchema): string {
+    if (typeof schema === 'string') {
+      return schema;
+    }
+
     return JSON.stringify(
       isZodObject(schema) ? zodToJsonSchema(schema as ZodObject<ZodRawShape>) : schema,
     );

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,7 +18,7 @@ export type ApiConfig = ApiKeyConfig | X402Config;
 
 export type Structured = Record<string, unknown>;
 
-export type StructuredInputSchema = Structured | ZodObject<ZodRawShape>;
+export type StructuredInputSchema = Structured | string | ZodObject<ZodRawShape>;
 
 export type FetchImage = {
   alt: string;


### PR DESCRIPTION
## Summary
- align `structuredOutputSchema` with the public API by accepting JSON schema strings in the JS SDK type surface
- avoid double-encoding pre-serialized schema strings before sending `/search` and `/research`
- add coverage for passing structured output schemas as JSON strings

## Validation
- `npm run build`
- `npm run lint`
- `npm test`
