### PR TITLE
fix: tolerate unsupported task variants

### DIFF
--- a/src/__tests__/linkup-client.test.ts
+++ b/src/__tests__/linkup-client.test.ts
@@ -644,6 +644,74 @@ describe('LinkupClient', () => {
       expect(result.quota.inFlight).toBe(1);
     });
 
+    it('should preserve unsupported task variants returned by the API', async () => {
+      mockAxiosInstance.get.mockResolvedValueOnce({
+        data: {
+          data: [
+            {
+              createdAt: '2026-05-18T00:00:00.000Z',
+              error: null,
+              id: 'extract-task-1',
+              input: {
+                q: 'companies founded in paris',
+                schema: {
+                  type: 'object',
+                },
+              },
+              output: {
+                rows: [{ company: 'Linkup' }],
+                rowsReturned: 1,
+              },
+              status: 'completed',
+              type: 'extract',
+              updatedAt: '2026-05-18T01:00:00.000Z',
+            },
+          ],
+          metadata: { page: 1, pageSize: 5, total: 1, totalPages: 1 },
+          quota: { inFlight: 1, limit: 100 },
+        },
+      } as AxiosResponse);
+
+      const result = await underTest.listTasks();
+
+      expect(result.data[0]).toMatchObject({
+        id: 'extract-task-1',
+        rawType: 'extract',
+        type: 'unsupported',
+      });
+      if (result.data[0].type === 'unsupported') {
+        expect(result.data[0].output).toEqual({
+          rows: [{ company: 'Linkup' }],
+          rowsReturned: 1,
+        });
+      }
+    });
+
+    it('should preserve unsupported tasks when fetching a single task', async () => {
+      mockAxiosInstance.get.mockResolvedValueOnce({
+        data: {
+          createdAt: '2026-05-18T00:00:00.000Z',
+          error: null,
+          id: 'extract-task-2',
+          input: {
+            q: 'companies founded in paris',
+          },
+          output: null,
+          status: 'processing',
+          type: 'extract',
+          updatedAt: '2026-05-18T01:00:00.000Z',
+        },
+      } as AxiosResponse);
+
+      const result = await underTest.getTask('extract-task-2');
+
+      expect(result).toMatchObject({
+        id: 'extract-task-2',
+        rawType: 'extract',
+        type: 'unsupported',
+      });
+    });
+
     it('should serialize repeated list task filters without array brackets', async () => {
       mockAxiosInstance.get.mockResolvedValueOnce({
         data: {

--- a/src/linkup-client.ts
+++ b/src/linkup-client.ts
@@ -298,7 +298,7 @@ export class LinkupClient {
           input: this.normalizeSearchLikeInput(normalizedTask.input),
         } as Task;
       case 'fetch':
-        return normalizedTask;
+        return normalizedTask as Task;
       case 'research':
         return {
           ...normalizedTask,

--- a/src/linkup-client.ts
+++ b/src/linkup-client.ts
@@ -286,7 +286,10 @@ export class LinkupClient {
   }
 
   private normalizeTask(task: unknown): Task {
-    const normalizedTask = task as Task & { input: Record<string, unknown> };
+    const normalizedTask = task as {
+      input: Record<string, unknown>;
+      type: string;
+    } & Record<string, unknown>;
 
     switch (normalizedTask.type) {
       case 'search':
@@ -300,6 +303,12 @@ export class LinkupClient {
         return {
           ...normalizedTask,
           input: this.normalizeSearchLikeInput(normalizedTask.input),
+        } as Task;
+      default:
+        return {
+          ...normalizedTask,
+          rawType: normalizedTask.type,
+          type: 'unsupported',
         } as Task;
     }
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -209,7 +209,11 @@ export type FetchTask = TaskBase<'fetch', FetchParams, FetchTaskOutput>;
 
 export type ResearchTask = TaskBase<'research', ResearchTaskInput, ResearchResult>;
 
-export type Task = SearchTask | FetchTask | ResearchTask;
+export type UnsupportedTask = TaskBase<'unsupported', Record<string, unknown>, unknown> & {
+  rawType: string;
+};
+
+export type Task = SearchTask | FetchTask | ResearchTask | UnsupportedTask;
 
 export type PaginationMetadata = {
   page: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -182,7 +182,7 @@ export type TaskRequest =
   | { type: 'fetch'; input: FetchParams }
   | { type: 'research'; input: ResearchParams };
 
-type TaskBase<TType extends TaskType, TInput, TOutput> = {
+type TaskBase<TType extends string, TInput, TOutput> = {
   createdAt: string;
   error: string | null;
   id: string;


### PR DESCRIPTION
## Summary
- platform `GET /tasks` and `GET /tasks/:id` responses can include task variants the JS SDK does not actively model yet
- add an `UnsupportedTask` output shape so `listTasks()` and `getTask()` preserve those responses instead of dropping them during normalization
- keep task creation and task-type filtering limited to the existing stable SDK task types

## Validation
- `npm run build`
- `npm run lint`
- `npm test`