### PR TITLE
fix: handle unsupported task types in task endpoints

### DIFF
--- a/src/__tests__/linkup-client.test.ts
+++ b/src/__tests__/linkup-client.test.ts
@@ -614,6 +614,29 @@ describe('LinkupClient', () => {
       }
     });
 
+    it('should reject unsupported task types returned by getTask', async () => {
+      mockAxiosInstance.get.mockResolvedValueOnce({
+        data: {
+          createdAt: '2026-05-18T00:00:00.000Z',
+          error: null,
+          id: 'task-extract',
+          input: {
+            q: 'hello',
+            url: 'https://example.com',
+          },
+          output: null,
+          status: 'pending',
+          type: 'extract',
+          updatedAt: '2026-05-18T01:00:00.000Z',
+        },
+      } as AxiosResponse);
+
+      const error = await underTest.getTask('task-extract').catch(e => e);
+
+      expect(error).toBeInstanceOf(LinkupUnknownError);
+      expect(error.message).toContain("unsupported task type 'extract'");
+    });
+
     it('should list tasks with filters and pagination', async () => {
       mockAxiosInstance.get.mockResolvedValueOnce({
         data: {
@@ -681,6 +704,35 @@ describe('LinkupClient', () => {
       expect(config.paramsSerializer(config.params)).toBe(
         'status=pending&status=processing&type=search&type=research',
       );
+    });
+
+    it('should reject unsupported task types returned by listTasks', async () => {
+      mockAxiosInstance.get.mockResolvedValueOnce({
+        data: {
+          data: [
+            {
+              createdAt: '2026-05-18T00:00:00.000Z',
+              error: null,
+              id: 'task-extract',
+              input: {
+                q: 'hello',
+                url: 'https://example.com',
+              },
+              output: null,
+              status: 'pending',
+              type: 'extract',
+              updatedAt: '2026-05-18T01:00:00.000Z',
+            },
+          ],
+          metadata: { page: 1, pageSize: 5, total: 1, totalPages: 1 },
+          quota: { inFlight: 1, limit: 100 },
+        },
+      } as AxiosResponse);
+
+      const error = await underTest.listTasks({ page: 1 }).catch(e => e);
+
+      expect(error).toBeInstanceOf(LinkupUnknownError);
+      expect(error.message).toContain("unsupported task type 'extract'");
     });
   });
 
@@ -782,6 +834,19 @@ describe('LinkupClient', () => {
         expectedMessage: 'Forbidden action',
         input: {
           error: { code: 'FORBIDDEN', details: [], message: 'Forbidden action' },
+          statusCode: 403,
+        },
+      },
+      {
+        description: '403 TASK_TYPE_NOT_SUPPORTED',
+        ErrorClass: LinkupUnknownError,
+        expectedMessage: 'Unsupported task type: Extract tasks are not enabled for this organization.',
+        input: {
+          error: {
+            code: 'TASK_TYPE_NOT_SUPPORTED',
+            details: [],
+            message: 'Extract tasks are not enabled for this organization.',
+          },
           statusCode: 403,
         },
       },

--- a/src/__tests__/linkup-client.test.ts
+++ b/src/__tests__/linkup-client.test.ts
@@ -840,7 +840,8 @@ describe('LinkupClient', () => {
       {
         description: '403 TASK_TYPE_NOT_SUPPORTED',
         ErrorClass: LinkupUnknownError,
-        expectedMessage: 'Unsupported task type: Extract tasks are not enabled for this organization.',
+        expectedMessage:
+          'Unsupported task type: Extract tasks are not enabled for this organization.',
         input: {
           error: {
             code: 'TASK_TYPE_NOT_SUPPORTED',

--- a/src/linkup-client.ts
+++ b/src/linkup-client.ts
@@ -2,7 +2,7 @@ import axios, { AxiosInstance } from 'axios';
 import { ZodObject, ZodRawShape } from 'zod';
 import zodToJsonSchema from 'zod-to-json-schema';
 import { version } from '../package.json';
-import { LinkupPaymentRequiredError } from './errors';
+import { LinkupPaymentRequiredError, LinkupUnknownError } from './errors';
 import {
   ApiConfig,
   FetchParams,
@@ -301,6 +301,10 @@ export class LinkupClient {
           ...normalizedTask,
           input: this.normalizeSearchLikeInput(normalizedTask.input),
         } as Task;
+      default:
+        throw new LinkupUnknownError(
+          `The Linkup API returned an unsupported task type '${String(normalizedTask.type)}'. This SDK supports search, fetch, and research tasks only.`,
+        );
     }
   }
 

--- a/src/linkup-client.ts
+++ b/src/linkup-client.ts
@@ -286,20 +286,23 @@ export class LinkupClient {
   }
 
   private normalizeTask(task: unknown): Task {
-    const normalizedTask = task as Task & { input: Record<string, unknown> };
+    const normalizedTask = task as {
+      input?: Record<string, unknown>;
+      type?: string;
+    } & Record<string, unknown>;
 
     switch (normalizedTask.type) {
       case 'search':
         return {
           ...normalizedTask,
-          input: this.normalizeSearchLikeInput(normalizedTask.input),
+          input: this.normalizeSearchLikeInput(normalizedTask.input ?? {}),
         } as Task;
       case 'fetch':
-        return normalizedTask;
+        return normalizedTask as Task;
       case 'research':
         return {
           ...normalizedTask,
-          input: this.normalizeSearchLikeInput(normalizedTask.input),
+          input: this.normalizeSearchLikeInput(normalizedTask.input ?? {}),
         } as Task;
       default:
         throw new LinkupUnknownError(

--- a/src/utils/refine-error.utils.ts
+++ b/src/utils/refine-error.utils.ts
@@ -55,8 +55,14 @@ export const refineError = (e: LinkupApiError): LinkupError => {
     case 402:
       return new LinkupPaymentRequiredError(message);
     case 401:
-    case 403:
       return new LinkupAuthenticationError(message);
+    case 403:
+      switch (code) {
+        case 'TASK_TYPE_NOT_SUPPORTED':
+          return new LinkupUnknownError(`Unsupported task type: ${message}`);
+        default:
+          return new LinkupAuthenticationError(message);
+      }
     case 404:
       switch (code) {
         case 'TASK_NOT_FOUND':


### PR DESCRIPTION
## Description

- the platform `/tasks` endpoints can now return the beta `extract` task type, while the JS SDK only supports stable `search`, `fetch`, and `research` tasks
- synchronized the SDK by turning unsupported task types into explicit `LinkupUnknownError` failures in `getTask` / `listTasks`, and by refining `TASK_TYPE_NOT_SUPPORTED` 403 responses away from misleading authentication errors
- added focused regression tests for unsupported task payloads and 403 error refinement

## Validation

- `npm run build`
- `npm run lint`
- `npm test`