### PR TITLE
fix: revert migration of workflows to Blacksmith runners

### DIFF
--- a/.github/workflows/_run-tests.yaml
+++ b/.github/workflows/_run-tests.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   run-tests:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         node-version: ["22.14.0", "24.14.0"]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
 
   build-and-publish:
     needs: run-tests
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
Reverts LinkupPlatform/linkup-js-sdk#25