### PR TITLE
fix: align task type support error handling

### DIFF
--- a/src/__tests__/linkup-client.test.ts
+++ b/src/__tests__/linkup-client.test.ts
@@ -11,6 +11,7 @@ import {
   LinkupNoResultError,
   LinkupPaymentRequiredError,
   LinkupTaskNotFoundError,
+  LinkupTaskTypeNotSupportedError,
   LinkupTasksQueueLimitExceededError,
   LinkupTooManyRequestsError,
   LinkupUnknownError,
@@ -839,9 +840,8 @@ describe('LinkupClient', () => {
       },
       {
         description: '403 TASK_TYPE_NOT_SUPPORTED',
-        ErrorClass: LinkupUnknownError,
-        expectedMessage:
-          'Unsupported task type: Extract tasks are not enabled for this organization.',
+        ErrorClass: LinkupTaskTypeNotSupportedError,
+        expectedMessage: 'Extract tasks are not enabled for this organization.',
         input: {
           error: {
             code: 'TASK_TYPE_NOT_SUPPORTED',

--- a/src/__tests__/linkup-client.test.ts
+++ b/src/__tests__/linkup-client.test.ts
@@ -11,8 +11,8 @@ import {
   LinkupNoResultError,
   LinkupPaymentRequiredError,
   LinkupTaskNotFoundError,
-  LinkupTaskTypeNotSupportedError,
   LinkupTasksQueueLimitExceededError,
+  LinkupTaskTypeNotSupportedError,
   LinkupTooManyRequestsError,
   LinkupUnknownError,
 } from '../errors';

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -59,6 +59,19 @@ export class LinkupTaskNotFoundError extends LinkupError {
   }
 }
 
+// Task type not supported error, raised when the Linkup API returns a 403 status code.
+// It is returned when a task type is not enabled for the current organization.
+export class LinkupTaskTypeNotSupportedError extends LinkupError {
+  constructor(message?: string) {
+    super(message);
+    this.name = LinkupTaskTypeNotSupportedError.name;
+
+    if ('captureStackTrace' in Error) {
+      Error.captureStackTrace(this, LinkupTaskTypeNotSupportedError);
+    }
+  }
+}
+
 // Insufficient credit error, raised when the Linkup API returns a 429 status code.
 // It is returned when you have run out of credits.
 export class LinkupInsufficientCreditError extends LinkupError {

--- a/src/utils/refine-error.utils.ts
+++ b/src/utils/refine-error.utils.ts
@@ -11,6 +11,7 @@ import {
   LinkupNoResultError,
   LinkupPaymentRequiredError,
   LinkupTaskNotFoundError,
+  LinkupTaskTypeNotSupportedError,
   LinkupTasksQueueLimitExceededError,
   LinkupTooManyRequestsError,
   LinkupUnknownError,
@@ -59,7 +60,7 @@ export const refineError = (e: LinkupApiError): LinkupError => {
     case 403:
       switch (code) {
         case 'TASK_TYPE_NOT_SUPPORTED':
-          return new LinkupUnknownError(`Unsupported task type: ${message}`);
+          return new LinkupTaskTypeNotSupportedError(message);
         default:
           return new LinkupAuthenticationError(message);
       }

--- a/src/utils/refine-error.utils.ts
+++ b/src/utils/refine-error.utils.ts
@@ -11,8 +11,8 @@ import {
   LinkupNoResultError,
   LinkupPaymentRequiredError,
   LinkupTaskNotFoundError,
-  LinkupTaskTypeNotSupportedError,
   LinkupTasksQueueLimitExceededError,
+  LinkupTaskTypeNotSupportedError,
   LinkupTooManyRequestsError,
   LinkupUnknownError,
 } from '../errors';


### PR DESCRIPTION
## Summary
- synchronize the JS SDK with the platforms `TASK_TYPE_NOT_SUPPORTED` task error contract
- add a dedicated `LinkupTaskTypeNotSupportedError` instead of surfacing that 403 as `LinkupUnknownError`
- update the error refinement tests to cover the platform-specific mapping

## Why
The platforms stable `/v1/tasks` surface returns a dedicated `TASK_TYPE_NOT_SUPPORTED` error code for unsupported task types, but the JS SDK still flattened that response into `LinkupUnknownError`.

## Validation
- `npm run build`
- `npm run lint`
- `npm test`