### PR TITLE
fix: handle fetch target unreachable errors

### DIFF
--- a/src/__tests__/linkup-client.test.ts
+++ b/src/__tests__/linkup-client.test.ts
@@ -5,6 +5,7 @@ import {
   LinkupBudgetLimitExceededError,
   LinkupFetchError,
   LinkupFetchResponseTooLargeError,
+  LinkupFetchTargetUnreachableError,
   LinkupFetchUnsupportedContentTypeError,
   LinkupInsufficientCreditError,
   LinkupInvalidRequestError,
@@ -794,6 +795,19 @@ describe('LinkupClient', () => {
             code: 'FETCH_RESPONSE_TOO_LARGE',
             details: [],
             message: 'The fetched response is too large',
+          },
+          statusCode: 400,
+        },
+      },
+      {
+        description: '400 FETCH_TARGET_UNREACHABLE',
+        ErrorClass: LinkupFetchTargetUnreachableError,
+        expectedMessage: 'The target URL could not be reached (connection failed or timed out)',
+        input: {
+          error: {
+            code: 'FETCH_TARGET_UNREACHABLE',
+            details: [],
+            message: 'The target URL could not be reached (connection failed or timed out)',
           },
           statusCode: 400,
         },

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -160,6 +160,17 @@ export class LinkupFetchResponseTooLargeError extends LinkupError {
   }
 }
 
+export class LinkupFetchTargetUnreachableError extends LinkupError {
+  constructor(message?: string) {
+    super(message);
+    this.name = LinkupFetchTargetUnreachableError.name;
+
+    if ('captureStackTrace' in Error) {
+      Error.captureStackTrace(this, LinkupFetchTargetUnreachableError);
+    }
+  }
+}
+
 export class LinkupFetchUnsupportedContentTypeError extends LinkupError {
   constructor(message?: string) {
     super(message);

--- a/src/utils/refine-error.utils.ts
+++ b/src/utils/refine-error.utils.ts
@@ -5,6 +5,7 @@ import {
   LinkupError,
   LinkupFetchError,
   LinkupFetchResponseTooLargeError,
+  LinkupFetchTargetUnreachableError,
   LinkupFetchUnsupportedContentTypeError,
   LinkupInsufficientCreditError,
   LinkupInvalidRequestError,
@@ -46,6 +47,8 @@ export const refineError = (e: LinkupApiError): LinkupError => {
           return new LinkupFetchError(message);
         case 'FETCH_RESPONSE_TOO_LARGE':
           return new LinkupFetchResponseTooLargeError(message);
+        case 'FETCH_TARGET_UNREACHABLE':
+          return new LinkupFetchTargetUnreachableError(message);
         case 'FETCH_UNSUPPORTED_CONTENT_TYPE':
           return new LinkupFetchUnsupportedContentTypeError(message);
         case 'FETCH_URL_IS_FILE':


### PR DESCRIPTION
## Description

The public `/v1/fetch` API surface now reports a dedicated `FETCH_TARGET_UNREACHABLE` 400 error code when Linkup cannot reach the target URL.

This PR synchronizes the JS SDK by:
- adding a dedicated `LinkupFetchTargetUnreachableError` export,
- mapping `FETCH_TARGET_UNREACHABLE` to that error in the client error refinement path,
- covering the new contract in the fetch error tests.

## Validation

- `npm run build`
- `npm run lint`
- `npm test`